### PR TITLE
Update 1.0.1

### DIFF
--- a/src/system_false/json/Json.java
+++ b/src/system_false/json/Json.java
@@ -17,6 +17,7 @@ package system_false.json;
 
 import system_false.json.content.JsonArray;
 import system_false.json.content.JsonObject;
+import system_false.json.content.JsonPath;
 import system_false.json.content.JsonValue;
 import system_false.json.parser.Json5Parser;
 import system_false.json.parser.ParserException;
@@ -106,7 +107,21 @@ public class Json {
      * @throws ParserException if an exception occurred during parsing
      */
     public static JsonObject parseJsonObject(String json) throws ParserException {
-        Json5Parser parser = Json5Parser.create(json);
+        return parseJsonObject(json, false);
+    }
+
+    /**
+     * Method parses {@code String} and create returns {@code JsonObject} for parsed text.
+     * If the index flag is specified, then all parsed objects will be indexed immediately.
+     * @param json JSON text
+     * @param index indexation flag
+     *
+     * @return parsed {@code JsonObject}
+     * @throws ParserException if an exception occurred during parsing
+     * @see JsonPath
+     */
+    public static JsonObject parseJsonObject(String json, boolean index) throws ParserException {
+        Json5Parser parser = Json5Parser.create(json, index);
         if ((parser.nextElement() & Json5Parser.ELEMENT_OBJECT) != 0)
             return parser.parseObject();
         else throw new IllegalArgumentException("first element is string is not JsonObject");
@@ -120,7 +135,21 @@ public class Json {
      * @throws ParserException if an exception occurred during parsing
      */
     public static JsonObject parseJsonObject(Reader json) throws ParserException {
-        Json5Parser parser = Json5Parser.create(json);
+        return parseJsonObject(json, false);
+    }
+
+    /**
+     * Method parses {@code Reader} text and create returns {@code JsonObject} for parsed text.
+     * If the index flag is specified, then all parsed objects will be indexed immediately.
+     * @param json JSON text reader
+     * @param index indexation flag
+     *
+     * @return parsed {@code JsonObject}
+     * @throws ParserException if an exception occurred during parsing
+     * @see JsonPath
+     */
+    public static JsonObject parseJsonObject(Reader json, boolean index) throws ParserException {
+        Json5Parser parser = Json5Parser.create(json, index);
         if ((parser.nextElement() & Json5Parser.ELEMENT_OBJECT) != 0)
             return parser.parseObject();
         else throw new IllegalArgumentException("first element is string is not JsonObject");
@@ -135,7 +164,21 @@ public class Json {
      * @throws ParserException if an exception occurred during parsing
      */
     public static JsonObject parseJsonObject(InputStream json) throws ParserException {
-        Json5Parser parser = Json5Parser.create(json);
+        return parseJsonObject(json, false);
+    }
+
+    /**
+     * Method parses {@code InputStream} containing JSON text and create returns {@code JsonObject}
+     * for parsed text. If the index flag is specified, then all parsed objects will be indexed immediately.
+     * @param json {@code InputStream} for JSON text
+     * @param index indexation flag
+     *
+     * @return parsed {@code JsonObject}
+     * @throws ParserException if an exception occurred during parsing
+     * @see JsonPath
+     */
+    public static JsonObject parseJsonObject(InputStream json, boolean index) throws ParserException {
+        Json5Parser parser = Json5Parser.create(json, index);
         if ((parser.nextElement() & Json5Parser.ELEMENT_OBJECT) != 0)
             return parser.parseObject();
         else throw new IllegalArgumentException("first element is string is not JsonObject");
@@ -151,7 +194,22 @@ public class Json {
      * @throws ParserException if an exception occurred during parsing
      */
     public static JsonObject parseJsonObject(InputStream json, Charset charset) throws ParserException {
-        Json5Parser parser = Json5Parser.create(json, charset);
+        return parseJsonObject(json, charset, false);
+    }
+
+    /**
+     * Method parses {@code InputStream} containing JSON text and create returns {@code JsonObject}
+     * for parsed text. If the index flag is specified, then all parsed objects will be indexed immediately.
+     * @param json {@code InputStream} for JSON text
+     * @param charset charset to use in parsing
+     * @param index indexation flag
+     *
+     * @return parsed {@code JsonObject}
+     * @throws ParserException if an exception occurred during parsing
+     * @see JsonPath
+     */
+    public static JsonObject parseJsonObject(InputStream json, Charset charset, boolean index) throws ParserException {
+        Json5Parser parser = Json5Parser.create(json, charset, index);
         if ((parser.nextElement() & Json5Parser.ELEMENT_OBJECT) != 0)
             return parser.parseObject();
         else throw new IllegalArgumentException("first element is string is not JsonObject");
@@ -165,7 +223,21 @@ public class Json {
      * @throws ParserException if an exception occurred during parsing
      */
     public static JsonArray parseJsonArray(String json) throws ParserException {
-        Json5Parser parser = Json5Parser.create(json);
+        return parseJsonArray(json, false);
+    }
+
+    /**
+     * Method parses {@code String} and create returns {@code JsonArray} for parsed text.
+     * If the index flag is specified, then all parsed objects will be indexed immediately.
+     * @param json JSON text
+     * @param index indexation flag
+     *
+     * @return parsed {@code JsonArray}
+     * @throws ParserException if an exception occurred during parsing
+     * @see JsonPath
+     */
+    public static JsonArray parseJsonArray(String json, boolean index) throws ParserException {
+        Json5Parser parser = Json5Parser.create(json, index);
         if ((parser.nextElement() & Json5Parser.ELEMENT_ARRAY) != 0)
             return parser.parseArray();
         else throw new IllegalArgumentException("first element is string is not JsonArray");
@@ -179,7 +251,21 @@ public class Json {
      * @throws ParserException if an exception occurred during parsing
      */
     public static JsonArray parseJsonArray(Reader json) throws ParserException {
-        Json5Parser parser = Json5Parser.create(json);
+        return parseJsonArray(json, false);
+    }
+
+    /**
+     * Method parses {@code Reader} text and create returns {@code JsonArray} for parsed text.
+     * If the index flag is specified, then all parsed objects will be indexed immediately.
+     * @param json JSON text reader
+     * @param index indexation flag
+     *
+     * @return parsed {@code JsonArray}
+     * @throws ParserException if an exception occurred during parsing
+     * @see JsonPath
+     */
+    public static JsonArray parseJsonArray(Reader json, boolean index) throws ParserException {
+        Json5Parser parser = Json5Parser.create(json, index);
         if ((parser.nextElement() & Json5Parser.ELEMENT_ARRAY) != 0)
             return parser.parseArray();
         else throw new IllegalArgumentException("first element is string is not JsonArray");
@@ -194,7 +280,21 @@ public class Json {
      * @throws ParserException if an exception occurred during parsing
      */
     public static JsonArray parseJsonArray(InputStream json) throws ParserException {
-        Json5Parser parser = Json5Parser.create(json);
+        return parseJsonArray(json, false);
+    }
+
+    /**
+     * Method parses {@code InputStream} containing JSON text and create returns {@code JsonArray}
+     * for parsed text. If the index flag is specified, then all parsed objects will be indexed immediately.
+     * @param json {@code InputStream} for JSON text
+     * @param index indexation flag
+     *
+     * @return parsed {@code JsonArray}
+     * @throws ParserException if an exception occurred during parsing
+     * @see JsonPath
+     */
+    public static JsonArray parseJsonArray(InputStream json, boolean index) throws ParserException {
+        Json5Parser parser = Json5Parser.create(json, index);
         if ((parser.nextElement() & Json5Parser.ELEMENT_ARRAY) != 0)
             return parser.parseArray();
         else throw new IllegalArgumentException("first element is string is not JsonArray");
@@ -210,7 +310,22 @@ public class Json {
      * @throws ParserException if an exception occurred during parsing
      */
     public static JsonArray parseJsonArray(InputStream json, Charset charset) throws ParserException {
-        Json5Parser parser = Json5Parser.create(json, charset);
+        return parseJsonArray(json, charset, false);
+    }
+
+    /**
+     * Method parses {@code InputStream} containing JSON text and create returns {@code JsonArray}
+     * for parsed text. If the index flag is specified, then all parsed objects will be indexed immediately.
+     * @param json {@code InputStream} for JSON text
+     * @param charset charset to use in parsing
+     * @param index indexation flag
+     *
+     * @return parsed {@code JsonArray}
+     * @throws ParserException if an exception occurred during parsing
+     * @see JsonPath
+     */
+    public static JsonArray parseJsonArray(InputStream json, Charset charset, boolean index) throws ParserException {
+        Json5Parser parser = Json5Parser.create(json, charset, index);
         if ((parser.nextElement() & Json5Parser.ELEMENT_ARRAY) != 0)
             return parser.parseArray();
         else throw new IllegalArgumentException("first element is string is not JsonArray");
@@ -343,11 +458,11 @@ public class Json {
         level++;
         while (json.nextReadable(next)) {
             if (next[0] == '}') {
-                sb.append(" ".repeat(4 * --level)).append('}');
+                sb.append(spaces(4 * --level)).append('}');
                 return;
             }
             if (sb.charAt(sb.length() - 1) == '\n')
-                sb.append(" ".repeat(4 * level));
+                sb.append(spaces(4 * level));
             if (next[0] == '"' || next[0] == '\'') {
                 json.reread();
                 beautifyString(json, sb);
@@ -371,11 +486,11 @@ public class Json {
         level++;
         while (json.nextReadable(next)) {
             if (next[0] == ']') {
-                sb.append(" ".repeat(4 * --level)).append(']');
+                sb.append(spaces(4 * --level)).append(']');
                 return;
             }
             if (sb.charAt(sb.length() - 1) == '\n')
-                sb.append(" ".repeat(4 * level));
+                sb.append(spaces(4 * level));
             if (next[0] == '"' || next[0] == '\'') {
                 json.reread();
                 beautifyString(json, sb);
@@ -389,5 +504,13 @@ public class Json {
                 sb.append(",\n");
             } else sb.append(next[0]);
         }
+    }
+
+    private static String spaces(int count) {
+        StringBuilder spaces = new StringBuilder();
+        for (int i = 0; i < count; i++) {
+            spaces.append(' ');
+        }
+        return spaces.toString();
     }
 }

--- a/src/system_false/json/content/BooleanValue.java
+++ b/src/system_false/json/content/BooleanValue.java
@@ -25,6 +25,11 @@ package system_false.json.content;
  */
 public final class BooleanValue implements JsonValue {
     /**
+     * Path to this element.
+     */
+    JsonPath.BuildablePath path = new JsonPath.BuildablePath();
+
+    /**
      * Primitive {@code boolean} value of this object.
      */
     private final boolean value;
@@ -95,6 +100,11 @@ public final class BooleanValue implements JsonValue {
     }
 
     @Override
+    public JsonPath getPath() {
+        return path;
+    }
+
+    @Override
     public BooleanValue clone() {
         BooleanValue clone;
         try {
@@ -102,6 +112,7 @@ public final class BooleanValue implements JsonValue {
         } catch (CloneNotSupportedException e) {
             throw new RuntimeException(e);
         }
+        clone.path = path.clone();
         return clone;
     }
 

--- a/src/system_false/json/content/DecimalValue.java
+++ b/src/system_false/json/content/DecimalValue.java
@@ -119,6 +119,7 @@ public final class DecimalValue extends NumberValue {
         } catch (CloneNotSupportedException e) {
             throw new RuntimeException(e);
         }
+        clone.path = path.clone();
         return clone;
     }
 

--- a/src/system_false/json/content/InfinityValue.java
+++ b/src/system_false/json/content/InfinityValue.java
@@ -46,7 +46,7 @@ public final class InfinityValue extends NumberValue {
 
     @Override
     public String toJson5String() {
-        return "" + (negative ? Double.NEGATIVE_INFINITY : Double.POSITIVE_INFINITY);
+        return String.valueOf(negative ? Double.NEGATIVE_INFINITY : Double.POSITIVE_INFINITY);
     }
 
     @Override
@@ -122,6 +122,7 @@ public final class InfinityValue extends NumberValue {
         } catch (CloneNotSupportedException e) {
             throw new RuntimeException(e);
         }
+        clone.path = path.clone();
         return clone;
     }
 

--- a/src/system_false/json/content/IntegerValue.java
+++ b/src/system_false/json/content/IntegerValue.java
@@ -159,6 +159,7 @@ public final class IntegerValue extends NumberValue {
         } catch (CloneNotSupportedException e) {
             throw new RuntimeException(e);
         }
+        clone.path = path.clone();
         return clone;
     }
 

--- a/src/system_false/json/content/JsonArrayBuilder.java
+++ b/src/system_false/json/content/JsonArrayBuilder.java
@@ -25,11 +25,13 @@ import java.math.BigInteger;
  * must be used. Default constructor is private so to create an instance
  * of this class methods {@link #create()} and {@link #create(JsonArray)}
  * should be used.
- * @see #build()
+ * @see #build(boolean)
  * @see #create()
  * @see #create(JsonArray)
  */
 public class JsonArrayBuilder implements StructureBuilder {
+    private static final String PACKAGE_NAME = JsonArrayBuilder.class.getPackage().getName();
+
     /**
      * Field that contains constructing instance of {@code JsonArray}.
      */
@@ -59,16 +61,17 @@ public class JsonArrayBuilder implements StructureBuilder {
      * Method adds to the end of JSON array {@code null} element.
      *
      * @return this builder
-     * @throws IllegalStateException if method {@link #build()} was invoked before
+     * @throws IllegalStateException if method {@link #build(boolean)} was invoked before
      */
     public JsonArrayBuilder addNull() {
-        return add(NullValue.NULL);
+        return add(new NullValue());
     }
+
     /**
      * Method adds to the end of JSON array {@code boolean} element.
      *
      * @return this builder
-     * @throws IllegalStateException if method {@link #build()} was invoked before
+     * @throws IllegalStateException if method {@link #build(boolean)} was invoked before
      * @see BooleanValue#BooleanValue(boolean)
      */
     public JsonArrayBuilder addBoolean(boolean value) {
@@ -79,7 +82,7 @@ public class JsonArrayBuilder implements StructureBuilder {
      * Method adds to the end of JSON array {@code long} element.
      *
      * @return this builder
-     * @throws IllegalStateException if method {@link #build()} was invoked before
+     * @throws IllegalStateException if method {@link #build(boolean)} was invoked before
      * @see InfinityValue#InfinityValue()
      */
     public JsonArrayBuilder addNumber(long value) {
@@ -91,7 +94,7 @@ public class JsonArrayBuilder implements StructureBuilder {
      * radix.
      *
      * @return this builder
-     * @throws IllegalStateException if method {@link #build()} was invoked before
+     * @throws IllegalStateException if method {@link #build(boolean)} was invoked before
      * @see IntegerValue#IntegerValue(long, int)
      */
     public JsonArrayBuilder addNumber(long value, int radix) {
@@ -102,7 +105,7 @@ public class JsonArrayBuilder implements StructureBuilder {
      * Method adds to the end of JSON array {@code BigInteger} element.
      *
      * @return this builder
-     * @throws IllegalStateException if method {@link #build()} was invoked before
+     * @throws IllegalStateException if method {@link #build(boolean)} was invoked before
      * @see IntegerValue#IntegerValue(BigInteger)
      */
     public JsonArrayBuilder addNumber(BigInteger value) {
@@ -114,7 +117,7 @@ public class JsonArrayBuilder implements StructureBuilder {
      * given radix.
      *
      * @return this builder
-     * @throws IllegalStateException if method {@link #build()} was invoked before
+     * @throws IllegalStateException if method {@link #build(boolean)} was invoked before
      * @see IntegerValue#IntegerValue(BigInteger, int)
      */
     public JsonArrayBuilder addNumber(BigInteger value, int radix) {
@@ -125,7 +128,7 @@ public class JsonArrayBuilder implements StructureBuilder {
      * Method adds to the end of JSON array {@code double} element.
      *
      * @return this builder
-     * @throws IllegalStateException if method {@link #build()} was invoked before
+     * @throws IllegalStateException if method {@link #build(boolean)} was invoked before
      * @see DecimalValue#DecimalValue(double)
      */
     public JsonArrayBuilder addNumber(double value) {
@@ -136,7 +139,7 @@ public class JsonArrayBuilder implements StructureBuilder {
      * Method adds to the end of JSON array {@code BigDecimal} element.
      *
      * @return this builder
-     * @throws IllegalStateException if method {@link #build()} was invoked before
+     * @throws IllegalStateException if method {@link #build(boolean)} was invoked before
      * @see DecimalValue#DecimalValue(BigDecimal)
      */
     public JsonArrayBuilder addNumber(BigDecimal value) {
@@ -149,12 +152,12 @@ public class JsonArrayBuilder implements StructureBuilder {
      * will throw an exception.
      *
      * @return this builder
-     * @throws IllegalStateException if method {@link #build()} was invoked before
+     * @throws IllegalStateException if method {@link #build(boolean)} was invoked before
      * @see NaNValue
      * @see JsonElement#toJsonString()
      */
     public JsonArrayBuilder addNaN() {
-        return add(NaNValue.NaN);
+        return add(new NaNValue());
     }
 
     /**
@@ -163,7 +166,7 @@ public class JsonArrayBuilder implements StructureBuilder {
      * will throw an exception.
      *
      * @return this builder
-     * @throws IllegalStateException if method {@link #build()} was invoked before
+     * @throws IllegalStateException if method {@link #build(boolean)} was invoked before
      * @see InfinityValue#InfinityValue()
      * @see JsonElement#toJsonString()
      */
@@ -177,7 +180,7 @@ public class JsonArrayBuilder implements StructureBuilder {
      * will throw an exception.
      *
      * @return this builder
-     * @throws IllegalStateException if method {@link #build()} was invoked before
+     * @throws IllegalStateException if method {@link #build(boolean)} was invoked before
      * @see InfinityValue#InfinityValue(boolean)
      * @see JsonElement#toJsonString()
      */
@@ -189,7 +192,7 @@ public class JsonArrayBuilder implements StructureBuilder {
      * Method adds to the end of JSON array {@code String} element.
      *
      * @return this builder
-     * @throws IllegalStateException if method {@link #build()} was invoked before
+     * @throws IllegalStateException if method {@link #build(boolean)} was invoked before
      * @see StringValue#StringValue(String)
      */
     public JsonArrayBuilder addString(String value) {
@@ -201,7 +204,7 @@ public class JsonArrayBuilder implements StructureBuilder {
      *
      * @return this builder
      * @throws NullPointerException if builder is null
-     * @throws IllegalStateException if method {@link #build()} was invoked before
+     * @throws IllegalStateException if method {@link #build(boolean)} was invoked before
      */
     public JsonArrayBuilder addArray(JsonArrayBuilder builder) {
         return add(builder.value.clone());
@@ -212,7 +215,7 @@ public class JsonArrayBuilder implements StructureBuilder {
      *
      * @return this builder
      * @throws NullPointerException if builder is null
-     * @throws IllegalStateException if method {@link #build()} was invoked before
+     * @throws IllegalStateException if method {@link #build(boolean)} was invoked before
      * @see JsonObjectBuilder
      */
     public JsonArrayBuilder addObject(JsonObjectBuilder builder) {
@@ -224,13 +227,15 @@ public class JsonArrayBuilder implements StructureBuilder {
      * it will be skipped without exception.
      *
      * @return this builder
-     * @throws IllegalStateException if method {@link #build()} was invoked before
+     * @throws IllegalStateException if method {@link #build(boolean)} was invoked before
      */
     public JsonArrayBuilder add(JsonElement element) {
         checkBuilt();
         if (element == null)
             throw new NullPointerException("null element");
-        value.values.add(element);
+        if (!element.getClass().getPackage().getName().equals(PACKAGE_NAME))
+            throw new IllegalArgumentException("element class is not supported");
+        value.values.add(element.copy());
         return this;
     }
 
@@ -239,7 +244,7 @@ public class JsonArrayBuilder implements StructureBuilder {
      *
      * @param index index of element to be removed
      * @return this builder
-     * @throws IllegalStateException if method {@link #build()} was invoked before
+     * @throws IllegalStateException if method {@link #build(boolean)} was invoked before
      * @throws IndexOutOfBoundsException if index is incorrect
      */
     public JsonArrayBuilder remove(int index) {
@@ -252,17 +257,17 @@ public class JsonArrayBuilder implements StructureBuilder {
      * Method removes first {@code null} element from JSON array.
      *
      * @return this builder
-     * @throws IllegalStateException if method {@link #build()} was invoked before
+     * @throws IllegalStateException if method {@link #build(boolean)} was invoked before
      */
     public JsonArrayBuilder removeNull() {
-        return remove(NullValue.NULL);
+        return remove(new NullValue());
     }
 
     /**
      * Method removes first {@code boolean} element with given value from JSON array.
      *
      * @return this builder
-     * @throws IllegalStateException if method {@link #build()} was invoked before
+     * @throws IllegalStateException if method {@link #build(boolean)} was invoked before
      * @see BooleanValue#BooleanValue(boolean)
      */
     public JsonArrayBuilder removeBoolean(boolean value) {
@@ -273,7 +278,7 @@ public class JsonArrayBuilder implements StructureBuilder {
      * Method removes first {@code long} element with given value from JSON array.
      *
      * @return this builder
-     * @throws IllegalStateException if method {@link #build()} was invoked before
+     * @throws IllegalStateException if method {@link #build(boolean)} was invoked before
      * @see IntegerValue#IntegerValue(long)
      */
     public JsonArrayBuilder removeNumber(long value) {
@@ -284,7 +289,7 @@ public class JsonArrayBuilder implements StructureBuilder {
      * Method removes first {@code BigInteger} element with given value from JSON array.
      *
      * @return this builder
-     * @throws IllegalStateException if method {@link #build()} was invoked before
+     * @throws IllegalStateException if method {@link #build(boolean)} was invoked before
      * @see IntegerValue#IntegerValue(BigInteger)
      */
     public JsonArrayBuilder removeNumber(BigInteger value) {
@@ -295,7 +300,7 @@ public class JsonArrayBuilder implements StructureBuilder {
      * Method removes first {@code double} element with given value from JSON array.
      *
      * @return this builder
-     * @throws IllegalStateException if method {@link #build()} was invoked before
+     * @throws IllegalStateException if method {@link #build(boolean)} was invoked before
      * @see DecimalValue#DecimalValue(double)
      */
     public JsonArrayBuilder removeNumber(double value) {
@@ -306,7 +311,7 @@ public class JsonArrayBuilder implements StructureBuilder {
      * Method removes first {@code BigDecimal} element with given value from JSON array.
      *
      * @return this builder
-     * @throws IllegalStateException if method {@link #build()} was invoked before
+     * @throws IllegalStateException if method {@link #build(boolean)} was invoked before
      * @see DecimalValue#DecimalValue(BigDecimal)
      */
     public JsonArrayBuilder removeNumber(BigDecimal value) {
@@ -317,7 +322,7 @@ public class JsonArrayBuilder implements StructureBuilder {
      * Method removes first {@code String} element with given value from JSON array.
      *
      * @return this builder
-     * @throws IllegalStateException if method {@link #build()} was invoked before
+     * @throws IllegalStateException if method {@link #build(boolean)} was invoked before
      * @see StringValue#StringValue(String)
      */
     public JsonArrayBuilder removeString(String value) {
@@ -330,7 +335,7 @@ public class JsonArrayBuilder implements StructureBuilder {
      *
      * @return this builder
      * @throws NullPointerException if builder is null
-     * @throws IllegalStateException if method {@link #build()} was invoked before
+     * @throws IllegalStateException if method {@link #build(boolean)} was invoked before
      */
     public JsonArrayBuilder removeArray(JsonArrayBuilder builder) {
         return remove(builder.value);
@@ -342,7 +347,7 @@ public class JsonArrayBuilder implements StructureBuilder {
      *
      * @return this builder
      * @throws NullPointerException if builder is null
-     * @throws IllegalStateException if method {@link #build()} was invoked before
+     * @throws IllegalStateException if method {@link #build(boolean)} was invoked before
      */
     public JsonArrayBuilder removeObject(JsonObjectBuilder builder) {
         return remove(builder.value);
@@ -353,11 +358,19 @@ public class JsonArrayBuilder implements StructureBuilder {
      *
      * @param element element to be removed
      * @return this builder
-     * @throws IllegalStateException if method {@link #build()} was invoked before
+     * @throws IllegalStateException if method {@link #build(boolean)} was invoked before
      */
     public JsonArrayBuilder remove(JsonElement element) {
         checkBuilt();
         if (element == null) return this;
+        if (element.isIndexed()) {
+            if (element instanceof JsonArray)
+                ((JsonArray) element).resolvePath(new JsonPath.BuildablePath());
+            else if (element instanceof JsonObject)
+                ((JsonObject) element).resolvePath(new JsonPath.BuildablePath());
+            else if (element.getPath() instanceof JsonPath.BuildablePath)
+                ((JsonPath.BuildablePath) element.getPath()).clear();
+        }
         value.values.remove(element);
         return this;
     }
@@ -369,6 +382,13 @@ public class JsonArrayBuilder implements StructureBuilder {
 
     @Override
     public JsonArray build() {
+        return build(false);
+    }
+
+    @Override
+    public JsonArray build(boolean setPath) {
+        if (built) return value;
+        if (setPath) value.resolvePath(new JsonPath.BuildablePath());
         built = true;
         return value;
     }

--- a/src/system_false/json/content/JsonElement.java
+++ b/src/system_false/json/content/JsonElement.java
@@ -74,4 +74,25 @@ public interface JsonElement extends Cloneable {
      * @return JSON representation of this object
      */
     String toString();
+
+    /**
+     * Method returns specified JSON path of this element. By default, it returns empty path.
+     *
+     * @return path of this element
+     * @see JsonPath
+     */
+    default JsonPath getPath() {
+        return JsonPath.empty();
+    }
+
+    /**
+     * Method return whether this element is indexed or not. Element is indexed when path is not empty.
+     *
+     * @return {@code true} if this element is indexed, {@code false} - otherwise
+     * @see #getPath()
+     * @see JsonPath
+     */
+    default boolean isIndexed() {
+        return !getPath().isEmpty();
+    }
 }

--- a/src/system_false/json/content/JsonPath.java
+++ b/src/system_false/json/content/JsonPath.java
@@ -1,0 +1,532 @@
+/*
+ * Copyright (c) 2023, SystemFalse. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ */
+
+package system_false.json.content;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.*;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Special view of path for JSON elements. This is similar to files system, but it has some
+ * differences. Objects of this class is used for indexing JSON elements. Path construction:
+ * <p>
+ * Root element can be any {@code JsonStructure}, more specifically {@link JsonObject} and {@link JsonArray}.
+ * To point to any element it is needed to write it's key, if root element is {@code JsonObject} or index
+ * in [] brackets, if root element is {@code JsonArray}.<br />
+ * For example, path "foo" will point to the element in {@code JsonObject}, named "foo".<br />
+ * Path "[2] will point to the element at index 2 in {@code JsonArray}.
+ * To point to next level object it is needed to add dot and to write key for next element.
+ * To point to next level array dot should not be set.<br />
+ * Two dots can not be placed to each other. It is incorrect path format. To point to empty named element,
+ * "\0" should be used.
+ * There are some restrictions for object names:
+ * <ul>
+ *     <li>name can not include brackets []</li>
+ *     <li>name can not include dots</li>
+ *     <li>name can not be \0, because of all this records will be replaced with empty strings</li>
+ * </ul>
+ *
+ * Example of usage:
+ * <pre>
+ * There is this JSON text:
+ * {
+ *     "foo": {
+ *         "bar": [
+ *             56,
+ *             90,
+ *             36
+ *         ],
+ *         "foo": {
+ *             "": 20
+ *         }
+ *     },
+ *     "bar": [
+ *         [
+ *             88,
+ *             69
+ *         ],
+ *         42
+ *     ]
+ * }
+ * </pre>
+ * Path "foo.bar[0]" will point to the element named "foo", then to the element named "bar" and
+ * to the zero index element in the "bar". So, this path is pointing to 56.<br />
+ * Path "bar[0]" will point to the element named "bar", then to the zero index element in "bar".
+ * So, this path is pointing to [88, 69]<br />
+ * Path "bar[0][1]" will point to the array like previous one and to the first index element in it.
+ * So, this path is pointing to 69.<br />
+ * Path "foo.foo.\0" will point to the element named "foo", then to the element named "foo" in
+ * "foo", and then to the empty named element in second "foo". So, this path is pointing to 20.
+ * </p>
+ */
+public class JsonPath implements Cloneable, Serializable {
+    /**
+     * This field is used in serialization.
+     */
+    private static final long serialVersionUID = -92387874838787L;
+
+    /**
+     * {@code String} view of {@code JsonPath}.
+     */
+    private String path;
+    /**
+     * List of functional converters.
+     */
+    private transient LinkedList<Resolver> resolvers;
+    /**
+     * Final functional converter.
+     */
+    private transient Resolver getter;
+
+    /**
+     * Private constructor that create {@code JsonPath} object with given path, resolvers and getter.
+     *
+     * @param path string view of {@code JsonPath}
+     * @param resolvers list of resolvers
+     * @param getter final resolver
+     */
+    private JsonPath(String path, LinkedList<Resolver> resolvers, Resolver getter) {
+        this.path = path;
+        this.resolvers = resolvers;
+        this.getter = getter;
+    }
+
+    /**
+     * Method returns {@code String} view of this path.
+     *
+     * @return {@code String} view of this path
+     */
+    public String getPath() {
+        return path;
+    }
+
+    /**
+     * Package-private method that finds element in given {@link JsonStructure}. If this path is empty,
+     * any search with will return given structure.
+     * @param structure root element for search
+     *
+     * @return found element
+     * @throws NoSuchElementException if given structure does not contain any of path elements
+     */
+    JsonElement get(JsonStructure structure) {
+        JsonElement element = structure;
+        for (Resolver fn : resolvers) {
+            try {
+                element = fn.apply(element);
+            } catch (RuntimeException e) {
+                throw exception(fn, e.getMessage());
+            }
+        }
+        try {
+            return getter.apply(element);
+        } catch (RuntimeException e) {
+            throw exception(getter, e.getMessage());
+        }
+    }
+
+    /**
+     * Method returns whether this path is empty. If this path is empty, any search with it will
+     * return given structure.
+     *
+     * @return {@code true} if this path is empty, {@code false} - otherwise
+     */
+    public boolean isEmpty() {
+        return path.isEmpty();
+    }
+
+    /**
+     * Method creates exception with message that contains path and element name.
+     * @param res resolver in which an exception occurred
+     * @param message common message
+     *
+     * @return new exception with specified message
+     */
+    private NoSuchElementException exception(Resolver res, String message) {
+        return new NoSuchElementException("path \"" + res.path() + "\", element \"" + res.current() + "\": " + message);
+    }
+
+    @Override
+    public JsonPath clone() {
+        try {
+            JsonPath clone = (JsonPath) super.clone();
+            LinkedList<Resolver> resolvers = new LinkedList<>();
+            clone.path = path.intern();
+            clone.getter = compile0(path, resolvers);
+            clone.resolvers = resolvers;
+            return clone;
+        } catch (CloneNotSupportedException e) {
+            throw new AssertionError();
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        JsonPath path1 = (JsonPath) o;
+
+        return path.equals(path1.path);
+    }
+
+    @Override
+    public int hashCode() {
+        return path.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return path;
+    }
+
+    /**
+     * Method writes this object to output stream during serialization.
+     * @param stream output stream
+     *
+     * @throws IOException if any exception during serialization occurred
+     */
+    private void writeObject(ObjectOutputStream stream) throws IOException {
+        stream.writeUTF(path);
+    }
+
+    /**
+     * Method read object from input stream during serialization.
+     * @param stream input stream
+     *
+     * @throws IOException if any exception during serialization occurred
+     */
+    private void readObject(ObjectInputStream stream) throws IOException {
+        path = stream.readUTF();
+        resolvers = new LinkedList<>();
+        if (!path.isEmpty()) getter = compile0(path, resolvers);
+        else getter = new EmptyPath();
+    }
+
+    /**
+     * Method makes this object as empty path.
+     */
+    private void readObjectNoData() {
+        path = "";
+        resolvers = new LinkedList<>();
+        getter = new EmptyPath();
+    }
+
+    /**
+     * Interface that represents {@code JsonElement} resolver.
+     */
+    private interface Resolver extends Function<JsonElement, JsonElement> {
+        /**
+         * Method returns {@code String} path to this resolver.
+         *
+         * @return {@code String} path to this resolver
+         */
+        String path();
+
+        /**
+         * Method returns name of this resolver.
+         *
+         * @return name of this resolver
+         */
+        String current();
+    }
+
+    /**
+     * Class that represents resolver that gets {@code JsonElement} from object.
+     */
+    private static class ObjectGet implements Resolver {
+        /**
+         * {@code String} view of path for this resolver.
+         */
+        final String path;
+        /**
+         * Name of this resolver.
+         */
+        final String name;
+
+        /**
+         * Constructor that creates resolver object using path and name.
+         * @param path path to this resolver
+         * @param name of this resolver
+         */
+        public ObjectGet(String path, String name) {
+            this.path = path;
+            this.name = name;
+        }
+
+        @Override
+        public String path() {
+            return path;
+        }
+
+        @Override
+        public String current() {
+            return name;
+        }
+
+        @Override
+        public JsonElement apply(JsonElement je) {
+            if (!(je instanceof JsonObject)) {
+                throw new RuntimeException("element is not object");
+            }
+            JsonObject jo = (JsonObject) je;
+            return jo.get(name);
+        }
+    }
+
+    /**
+     * Class that represents resolver that gets {@code JsonElement} from array.
+     */
+    private static class ArrayGet implements Resolver {
+        /**
+         * {@code String} view of path for this resolver.
+         */
+        final String path;
+        /**
+         * Index of this resolver.
+         */
+        final int index;
+
+        /**
+         * Constructor that creates resolver object using path and index.
+         * @param path path to this resolver
+         * @param index of this resolver
+         */
+        public ArrayGet(String path, int index) {
+            this.path = path;
+            this.index = index;
+        }
+
+        @Override
+        public String path() {
+            return path;
+        }
+
+        @Override
+        public String current() {
+            return "[" + index + "]";
+        }
+
+        @Override
+        public JsonElement apply(JsonElement je) {
+            if (!(je instanceof JsonArray)) {
+                throw new RuntimeException("element is not array");
+            }
+            JsonArray ja = (JsonArray) je;
+            return ja.get(index);
+        }
+    }
+
+    /**
+     * Class that represents resolver that returns given {@code JsonElement}.
+     */
+    private static class EmptyPath implements Resolver {
+        @Override
+        public String path() {
+            return "";
+        }
+
+        @Override
+        public String current() {
+            return "";
+        }
+
+        @Override
+        public JsonElement apply(JsonElement jsonElement) {
+            return jsonElement;
+        }
+    }
+
+    /**
+     * Pattern that checks {@code JsonPath} string.
+     */
+    private static final Pattern correctPath = Pattern.compile("(?:(?:[^\\[\\]\\.]+|\\\\0)|\\[(?:0|[1-9][0-9]*)\\])(\\.(?:[^\\[\\]\\.]+|\\\\0)|\\[(?:0|[1-9][0-9]*)\\])*");
+    /**
+     * Pattern that finds object name and array index in the path.
+     */
+    private static final Pattern pathPattern = Pattern.compile("(?<name>(?<=\\A|\\.|\\])[^\\[\\]\\.]+|\\\\0(?=\\z|\\.|\\[))|(?<index>(?<=\\[)0|[1-9][0-9]*(?=\\]))");
+
+    /**
+     * Method that creates final resolver using {@code String} view.
+     *
+     * @param path {@code String} view of path
+     * @param resolvers list of resolvers
+     *
+     * @return final resolver of given path
+     */
+    private static Resolver compile0(String path, LinkedList<Resolver> resolvers) {
+        if (path.isEmpty()) throw new IllegalArgumentException("path can not be empty");
+        if (!correctPath.matcher(path).matches()) throw new IllegalArgumentException("incorrect path");
+        Matcher m = pathPattern.matcher(path);
+        int begin = 0;
+        while (m.find(begin)) {
+            if (m.group("name") != null) {
+                if (m.group("name").equals("\\0"))
+                    resolvers.add(new ObjectGet(path.substring(0, m.start()), ""));
+                else
+                    resolvers.add(new ObjectGet(path.substring(0, m.start()), m.group("name")));
+            } else if (m.group("index") != null) {
+                resolvers.add(new ArrayGet(path.substring(0, m.start() - 1), Integer.parseInt(m.group("index"))));
+            }
+            begin = m.end();
+        }
+        return resolvers.removeLast();
+    }
+
+    /**
+     * Method creates new {@code JsonPath} using given path.
+     * @param path {@code String} view of path
+     *
+     * @return compiled {@code JsonPath}
+     */
+    public static JsonPath compile(String path) {
+        LinkedList<Resolver> resolvers = new LinkedList<>();
+        Resolver getter = compile0(path, resolvers);
+        return new JsonPath(path, resolvers, getter);
+    }
+
+    /**
+     * Method creates empty {@code JsonPath}. If this path will be used in method
+     * {@link JsonStructure#findElement(JsonPath)}, it will return the same object.
+     *
+     * @return empty {@code JsonPath}
+     */
+    public static JsonPath empty() {
+        return new JsonPath("", new LinkedList<>(), new EmptyPath());
+    }
+
+    /**
+     * Method indexes given JSON structure, that is, it assigns a path to each element and sub-element.
+     * To clear all paths, method {@link #clearPath(JsonElement)} should be used.
+     * @param structure JSON structure to index
+     *
+     * @see #clearPath(JsonElement)
+     */
+    public static void indexElements(JsonStructure structure) {
+        if (structure instanceof JsonArray) {
+            ((JsonArray) structure).resolvePath(new BuildablePath());
+        } else if (structure instanceof JsonObject) {
+            ((JsonObject) structure).resolvePath(new BuildablePath());
+        }
+    }
+
+    /**
+     * Method clears all paths from all elements and sub-elements of given JSON element.
+     * This method does the opposite of the method {@link #indexElements(JsonStructure)}.
+     * @param element JSON element to clear paths
+     *
+     * @see #indexElements(JsonStructure)
+     */
+    public static void clearPath(JsonElement element) {
+        if (element instanceof JsonArray) {
+            ((JsonArray) element).clearPath();
+        } else if (element instanceof JsonObject) {
+            ((JsonObject) element).clearPath();
+        } else if (element.getPath() instanceof JsonPath.BuildablePath) {
+            ((BuildablePath) element.getPath()).clear();
+        }
+    }
+
+    /**
+     * Method checks given name whether it can be used in indexed element and throws an exception
+     * if it can not be used that way.
+     * @param name name of {@code JsonElement} to check
+     *
+     * @throws IllegalArgumentException if given name can not be used for indexed {@code JsonElement}
+     */
+    public static void checkName(String name) {
+        if (name.equals("\\0")) throw new IllegalArgumentException();
+        else if (name.contains("[") || name.contains("]") || name.contains(".")) throw new IllegalArgumentException();
+    }
+
+    /**
+     * Class that represents modifiable {@link JsonPath}.
+     */
+    static class BuildablePath extends JsonPath {
+
+        /**
+         * Constructor that creates new {@code BuildablePath} object.
+         */
+        BuildablePath() {
+            super("", new LinkedList<>(), new EmptyPath());
+        }
+
+        /**
+         * Constructor that creates new {@code BuildablePath} object copying fields from
+         * given {@code Jsonpath}. It is used in method {@link #clone()}.
+         * @param copy {@code JsonPath} from which fields will be copied
+         */
+        private BuildablePath(JsonPath copy) {
+            super(copy.path, copy.resolvers, copy.getter);
+        }
+
+        /**
+         * Method adds object name to the end of this path. For example, if path was "foo",
+         * after invoking method add("bar"), path will be "foo.bar".
+         * @param objKey object key to add
+         */
+        void add(String objKey) {
+            if (!(super.getter instanceof EmptyPath)) {
+                super.resolvers.add(super.getter);
+            }
+            super.getter = new ObjectGet(super.path + ".", objKey);
+            super.path += "." + objKey;
+        }
+
+        /**
+         * Method add array index to the end of this path. For example, if path was "foo",
+         * after invoking method add(1), path will be "foo[1]".
+         * @param arrIndex array index to add
+         */
+        void add(int arrIndex) {
+            if (!(super.getter instanceof EmptyPath)) {
+                super.resolvers.add(super.getter);
+            }
+            super.getter = new ArrayGet(super.path, arrIndex);
+            super.path += "[" + arrIndex + "]";
+        }
+
+        /**
+         * Method sets array field like in given path.
+         * @param path path which fields will be set to this object
+         */
+        void set(JsonPath path) {
+            super.path = path.path;
+            super.resolvers.clear();
+            super.resolvers.addAll(path.resolvers);
+            super.getter = path.getter;
+        }
+
+        /**
+         * Method clears all information of path. {@link #path} will be empty,
+         * {@link #resolvers} will be cleared, {@link #getter} will be set to {@link EmptyPath}.
+         */
+        void clear() {
+            super.path = "";
+            super.resolvers.clear();
+            super.getter = new EmptyPath();
+        }
+
+        @Override
+        public BuildablePath clone() {
+            return new BuildablePath(super.clone());
+        }
+    }
+}

--- a/src/system_false/json/content/JsonStructure.java
+++ b/src/system_false/json/content/JsonStructure.java
@@ -15,6 +15,8 @@
 
 package system_false.json.content;
 
+import java.util.NoSuchElementException;
+
 /**
  * Common class for all JSON structures such are object and array.<br />
  * All these types can contain any json element.
@@ -72,5 +74,33 @@ public interface JsonStructure extends JsonElement {
      */
     default String toFormattedJson5() {
         return toJson5String(0);
+    }
+
+    default JsonElement findElement(String path) {
+        return findElement(JsonPath.compile(path));
+    }
+
+    default JsonElement findElement(JsonPath path) {
+        return path.get(this);
+    }
+
+    default JsonValue findValue(String path) {
+        return findValue(JsonPath.compile(path));
+    }
+
+    default JsonValue findValue(JsonPath path) {
+        JsonElement element = path.get(this);
+        if (element instanceof JsonValue) return (JsonValue) element;
+        else throw new NoSuchElementException("incorrect end element type");
+    }
+
+    default JsonStructure findStructure(String path) {
+        return findStructure(JsonPath.compile(path));
+    }
+
+    default JsonStructure findStructure(JsonPath path) {
+        JsonElement element = path.get(this);
+        if (element instanceof JsonStructure) return (JsonStructure) element;
+        else throw new NoSuchElementException("incorrect end element type");
     }
 }

--- a/src/system_false/json/content/NaNValue.java
+++ b/src/system_false/json/content/NaNValue.java
@@ -28,6 +28,11 @@ public final class NaNValue extends NumberValue {
      */
     public static final NaNValue NaN = new NaNValue();
 
+    /**
+     * Path to this element.
+     */
+    JsonPath.BuildablePath path = new JsonPath.BuildablePath();
+
     @Override
     public boolean isNaN() {
         return true;
@@ -106,6 +111,7 @@ public final class NaNValue extends NumberValue {
         } catch (CloneNotSupportedException e) {
             throw new RuntimeException(e);
         }
+        clone.path = path.clone();
         return clone;
     }
 

--- a/src/system_false/json/content/NullValue.java
+++ b/src/system_false/json/content/NullValue.java
@@ -30,6 +30,11 @@ public final class NullValue implements JsonValue {
      */
     public static final NullValue NULL = new NullValue();
 
+    /**
+     * Path to this element.
+     */
+    JsonPath.BuildablePath path = new JsonPath.BuildablePath();
+
     @Override
     public boolean isNull() {
         return true;
@@ -81,6 +86,11 @@ public final class NullValue implements JsonValue {
     }
 
     @Override
+    public JsonPath getPath() {
+        return path;
+    }
+
+    @Override
     public NullValue clone() {
         NullValue clone;
         try {
@@ -88,6 +98,7 @@ public final class NullValue implements JsonValue {
         } catch (CloneNotSupportedException e) {
             throw new RuntimeException(e);
         }
+        clone.path = path.clone();
         return clone;
     }
 

--- a/src/system_false/json/content/NumberValue.java
+++ b/src/system_false/json/content/NumberValue.java
@@ -28,6 +28,11 @@ import java.math.BigInteger;
  */
 public abstract class NumberValue extends Number implements JsonValue {
     /**
+     * Path to this element.
+     */
+    JsonPath.BuildablePath path = new JsonPath.BuildablePath();
+
+    /**
      * Method returns whether this number is NaN.
      *
      * @return {@code true} if this number is NaN, {@code false} otherwise
@@ -141,5 +146,10 @@ public abstract class NumberValue extends Number implements JsonValue {
         } catch (CloneNotSupportedException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @Override
+    public JsonPath getPath() {
+        return path;
     }
 }

--- a/src/system_false/json/content/StructureBuilder.java
+++ b/src/system_false/json/content/StructureBuilder.java
@@ -29,8 +29,25 @@ public interface StructureBuilder {
 
     /**
      * Method build JSON structure and returns it. After invoking this method
-     * any other methods that modify structure will be not available.
+     * any other methods that modify structure will be not available. By default,
+     * it calls method {@link #build(boolean)} with {@code false} parameter.
+     *
      * @return built JSON structure
+     * @see #build(boolean)
      */
-    JsonStructure build();
+    default JsonStructure build() {
+        return build(false);
+    }
+
+    /**
+     * Method build JSON structure and returns it. After invoking this method
+     * any other methods that modify structure will be not available. This method also can index
+     * all element in the structure. That means that every element in this structure and all
+     * included structures will have own path which can be gotten by method {@link JsonElement#getPath()}.
+     * @param setPath if true, all elements in building structure will be indexed
+     *
+     * @return built JSON structure
+     * @see JsonPath
+     */
+    JsonStructure build(boolean setPath);
 }

--- a/src/system_false/json/parser/PreParser.java
+++ b/src/system_false/json/parser/PreParser.java
@@ -17,7 +17,6 @@ package system_false.json.parser;
 
 import java.io.IOException;
 import java.io.Reader;
-import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
@@ -283,11 +282,17 @@ public class PreParser {
             @Override
             public int read(char[] cbuf, int off, int len) throws IOException {
                 ensureClose();
-                Objects.checkFromIndexSize(off, len, cbuf.length);
+                checkFromIndexSize(off, len, cbuf.length);
                 char[] ch = new char[1];
                 int i = 0;
                 for (; i < len && next(ch); i++) cbuf[off + i] = ch[0];
                 return i;
+            }
+
+            private void checkFromIndexSize(int off, int len, int length) {
+                if ((off | len) < 0 || off + len > length)
+                    throw new IndexOutOfBoundsException(
+                            "index " + off + " of sub length " + len + " and length " + length);
             }
 
             @Override


### PR DESCRIPTION
- Added new class `JsonPath` that can help to search elements in deep JSON structures.
- All JSON elements now can have own path. It can be get with method `JsonElement.getPath()`. But before, this element must be indexed by method `JsonPath.indexElements(JsonStructure structure)` or while building structure with builder `StructureBuilder.build(true)`.
- `JsonStructure` now has new methods: `findElement(JsonPath path)`, `findValue(JsonPath path)` and `findStructure(JsonPath path)`
- If there is a need to clear path of JSON elements, the method `JsonPath.clearPath(JsonElement element)` can be used.